### PR TITLE
make "Content-Length" header regex not case sensitive

### DIFF
--- a/lib/mjpeg-consumer.js
+++ b/lib/mjpeg-consumer.js
@@ -1,6 +1,6 @@
 require("buffertools");
 
-var length = /Content-Length: \d+/;
+var lengthExpression = /Content-Length: \d+/i;
 var soi = new Buffer(2);
 soi.writeUInt16LE(0xd8ff, 0);
 
@@ -18,7 +18,7 @@ require('util').inherits(MjpegConsumer, require('stream'));
 MjpegConsumer.prototype.write = function(chunk) {
     var len, start, initialBytes, remaining, soiIndex;
 
-    if (chunk.length < this.totalBytes - this.bytesWritten) {         
+    if (chunk.length < this.totalBytes - this.bytesWritten) {
         chunk.copy(this.buffer, this.bytesWritten, 0, chunk.length);
         this.bytesWritten += chunk.length;
         return;
@@ -30,7 +30,7 @@ MjpegConsumer.prototype.write = function(chunk) {
         this.bytesWritten += remaining;
     }
 
-    len = length.exec(chunk);
+    len = lengthExpression.exec(chunk);
     if (len) {
         if (this.initialized) {
             this.emit('data', this.buffer);
@@ -44,7 +44,7 @@ MjpegConsumer.prototype.write = function(chunk) {
 
     start = chunk.indexOf(soi);
     if (start !== -1) {
-        initialBytes = (chunk.length - start);    
+        initialBytes = (chunk.length - start);
         chunk.copy(this.buffer, 0, start, chunk.length);
         this.bytesWritten += initialBytes;
     }


### PR DESCRIPTION
Ran into this pulling from some d-link camera that was sending the all lowercase header fields.  
