### PR TITLE
Copy over the eoi marker

### DIFF
--- a/lib/mjpeg-consumer.js
+++ b/lib/mjpeg-consumer.js
@@ -54,7 +54,7 @@ MjpegConsumer.prototype._transform = function(chunk, encoding, done) {
         end = chunk.indexOf(eoi);
         // If we're at the end of the image, copy over until we hit the eoi marker
         if (end !== -1) {
-            this.concatImageBytes(chunk.slice(0, end));
+            this.concatImageBytes(chunk.slice(0, end + eoi.length));
             this.eoiFound = true;
         }
         // Otherwise, copy over all the chunk data and call `done()` 


### PR DESCRIPTION
The code should copy over the eoi marker to properly terminate the jpeg data.