### PR TITLE
Decode chunk as ascii for the regex instead of the default utf8

### DIFF
--- a/lib/mjpeg-consumer.js
+++ b/lib/mjpeg-consumer.js
@@ -97,7 +97,7 @@ MjpegConsumer.prototype._sendFrame = function() {
 MjpegConsumer.prototype._transform = function(chunk, encoding, done) {
   var start = chunk.indexOf(soi);
   var end = chunk.indexOf(eoi);
-  var len = (lengthRegex.exec(chunk) || [])[1];
+  var len = (lengthRegex.exec(chunk.toString('ascii')) || [])[1];
 
   if (this.buffer && (this.reading || start > -1)) {
     this._readFrame(chunk, start, end);


### PR DESCRIPTION
I did some profiling on the code and the most expensive part is converting the chunk to utf8 for the regex. Converting it to ascii is much faster. We know the headers are ascii so it seems like a safe optimisation.